### PR TITLE
Added Windows-based steps and options to README

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -59,28 +59,28 @@ services.AddSingleton<IEventProcessor>(sp =>
 4. The `KafkaEventConsumer` in **Sample Worker** subscribes to the "raw-events" topic of the Kafka broker running on `localhost:9092`. The message handlers validate, enrich and filter the events one at a time. If there are validation errors, those are written back to Kafka with a "validation-errors" topic. This takes place if the message key does not correlate to a key in the language store. The `EnrichmentHandler` looks up a translation for "Hello" in the language store and transforms the message with the selected translation. The `FilterHandler` accepts a lambda expression for filtering messages. In this case the English phrase "Hello" is filtered out. Lastly, the `KafkaEventProducer` writes processed events back to Kafka using the "final-events" topic.
 5. The **Sample Consumer** console app reads the "validation-errors" and "final-events" topics, displaying them in the console.
 
-## Running the Sample Locally
+## Running the Sample Locally (MacOS)
 
 > **Note**: To run Kafka you will need to allocate 8 GB of memory to Docker Desktop.
 
-1. Start up Kafka using the following command at the project root.
+#### 1. Start up Kafka using the following command at the project root.
 ```
 docker-compose up --build -d
 ```
    - Run `docker-compose ps` to verify Kafka services are up and running.
    - Open the control center at http://localhost:9021/
    - Wait until **controlcenter.cluster** is in a running state.
-2. In a new terminal start the **Sample Worker** service.
+#### 2. In a new terminal start the **Sample Worker** service.
 ```
 cd samples/EventStreamProcessing.Sample.Worker
 dotnet run
 ```
-3. In a new terminal start the **Sample Consumer** app.
+#### 3. In a new terminal start the **Sample Consumer** app.
 ```
 cd samples/EventStreamProcessing.Sample.Consumer
 dotnet run
 ```
-4. In a new terminal start the **Sample Producer** app.
+#### 4. In a new terminal start the **Sample Producer** app.
 ```
 cd samples/EventStreamProcessing.Sample.Producer
 dotnet run
@@ -101,12 +101,102 @@ dotnet run
    - Event 4 should be filtered out.
    - Event 5 will produce a validation error.
    - Observe logging performed by the **Sample Worker** service.
-5. You can terminate the consumer, producer and worker processes by pressing `Ctrl+C`.
-6. Terminate Kafka by entering `docker-compose down`.
+
+#### 5. Shutdown, Cleanup and Releasing Resources
+
+1. You can terminate the consumer, producer and worker processes by pressing `Ctrl+C`.
+2. Terminate Kafka by entering `docker-compose down`. This will shut down the 4 services running in Docker, clean up the resources and breakdown the custom kafka network adapter.
+
+## Running the Sample Locally (Windows)
+
+#### 1. Start up Kafka using the following command at the project root.
+```
+docker-compose up --build -d
+```
+   - Run `docker-compose ps` to verify Kafka services are up and running.
+   - Open the control center at http://localhost:9021/
+   - Wait until **controlcenter.cluster** is in a running state.
+
+#### 2. Start an instance of the **Sample Worker** service.
+
+    Option 1. Open a new Powershell window and run the following command:
+
+    ```
+    cd samples/EventStreamProcessing.Sample.Worker
+    dotnet run
+    ```
+
+    Option 2. Visual Studio 2019
+
+    1. Right-click on the `EventStreamProcessing.Sample.Worker` project in the Solution Explorer and select *Set as Startup Project*
+    2. Right-Click on the project again and select "Rebuild"
+    3. Press `CTRL + F5` (aka 'start without debugging') 
+
+#### 3. Start an instance of the the **Sample Consumer** app.
+
+    Option 1. Open a new PowerShell window and run the following commands
+
+    ```
+    cd samples/EventStreamProcessing.Sample.Consumer
+    dotnet run
+    ```
+
+    Option 2. Using Visual Studio 2019
+
+    1. Right-click on the `EventStreamProcessing.Sample.Consumer` project in the Solution Explorer and select *Set as Startup Project*
+    2. Right-Click on the project again and select "Rebuild"
+    3. Press `CTRL + F5` (aka 'start without debugging') 
+
+    > Bonus: If you are using a WPF app or other GUI for the consumer, start that up now as well.
+
+#### 4. In a new terminal start the **Sample Producer** app.
+
+    Option 1. Open a new PowerShell window and run the following commands
+
+    ```
+    cd samples/EventStreamProcessing.Sample.Producer
+    dotnet run
+    ```
+
+    Option 2. Using Visual Studio 2019
+
+    1. Right-click on the `EventStreamProcessing.Sample.Producer` project in the Solution Explorer and select *Set as Startup Project*
+    2. Right-Click on the project again and select "Rebuild"
+    3. Press `CTRL + F5` (aka 'start without debugging') 
+
+At this point, you should be able to see something similar to the following screenshot; with the Producer, Worker and Confluent running.
+
+![clusters, producer and worker](https://user-images.githubusercontent.com/3520532/96299318-df09d380-0fc1-11eb-9669-24b5c7308cfe.png)
+
+   - In the **Sample.Producer** window, enter `1 Hello World` and press Enter. ![enter message](https://user-images.githubusercontent.com/3520532/96301410-2776c080-0fc5-11eb-9ac5-c76ce8bc64a3.png)
+   - Observe output in the **Sample.Consumer** window.
+
+For example, try the following up until you reach 5. Enter additional messages in the **Sample Producer** app
+
+```
+> 2 Hello World
+> 3 Hello World
+> 4 Hello World
+> 5 Hello World
+```
+
+   - Output should display processed events for **2** and **3**
+   - Event **4** should be filtered out.
+   - Event **5** will produce a validation error.
+   - Observe logging performed by the **Sample.Worker** service.
+   
+ > Bonus : If you added a GUI Consumer application (e.g. WPF .NET Core), here's what that might look like at runtime (click to enlarge) ![runtime with WPF](https://user-images.githubusercontent.com/3520532/96300100-01e8b780-0fc3-11eb-9c63-3c1033944798.png)
+   
+#### 5. Shutdown, Cleanup and Releasing Resources
+
+1. You can terminate the consumer, producer and worker processes by pressing `Ctrl+C`.
+2. Terminate Kafka by entering `docker-compose down`. This will shut down the 4 services running in Docker, clean up the resources and breakdown the custom kafka network adapter.
 
 ## Running the Sample Worker using Docker
 
-If you want to deploy your event processing application to a Cloud provider, such as Amazon ECS, you will want to run the **Sample Worker** service locally using Docker. Since it will need to be a part of the same network as Kafka, it's easiest to use **Docker Compose** for this. Just open a terminal at the **EventStreamProcessing.Sample.Worker** directory and run the following.
+If you want to deploy your event processing application to a Cloud provider, such as Amazon ECS, you will want to run the **Sample Worker** service locally using Docker. Since it will need to be a part of the same network as Kafka, it's easiest to use **Docker Compose** for this. 
+
+We already have the Docker config prepared, just open a terminal/PowerShell at the **EventStreamProcessing.Sample.Worker** directory and run the following command.
 ```
 docker-compose up
 ```

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -119,50 +119,50 @@ docker-compose up --build -d
 
 #### 2. Start an instance of the **Sample Worker** service.
 
-    Option 1. Open a new Powershell window and run the following command:
+Option 1. Open a new Powershell window and run the following command:
 
-    ```
-    cd samples/EventStreamProcessing.Sample.Worker
-    dotnet run
-    ```
+```
+cd samples/EventStreamProcessing.Sample.Worker
+dotnet run
+```
 
-    Option 2. Visual Studio 2019
+Option 2. Visual Studio 2019
 
-    1. Right-click on the `EventStreamProcessing.Sample.Worker` project in the Solution Explorer and select *Set as Startup Project*
-    2. Right-Click on the project again and select "Rebuild"
-    3. Press `CTRL + F5` (aka 'start without debugging') 
+  1. Right-click on the `EventStreamProcessing.Sample.Worker` project in the Solution Explorer and select *Set as Startup Project*
+  2. Right-Click on the project again and select "Rebuild"
+  3. Press `CTRL + F5` (aka 'start without debugging') 
 
 #### 3. Start an instance of the the **Sample Consumer** app.
 
-    Option 1. Open a new PowerShell window and run the following commands
+Option 1. Open a new PowerShell window and run the following commands
 
-    ```
-    cd samples/EventStreamProcessing.Sample.Consumer
-    dotnet run
-    ```
+```
+cd samples/EventStreamProcessing.Sample.Consumer
+dotnet run
+```
 
-    Option 2. Using Visual Studio 2019
+Option 2. Using Visual Studio 2019
 
-    1. Right-click on the `EventStreamProcessing.Sample.Consumer` project in the Solution Explorer and select *Set as Startup Project*
-    2. Right-Click on the project again and select "Rebuild"
-    3. Press `CTRL + F5` (aka 'start without debugging') 
+  1. Right-click on the `EventStreamProcessing.Sample.Consumer` project in the Solution Explorer and select *Set as Startup Project*
+  2. Right-Click on the project again and select "Rebuild"
+  3. Press `CTRL + F5` (aka 'start without debugging') 
 
-    > Bonus: If you are using a WPF app or other GUI for the consumer, start that up now as well.
+  > Bonus: If you are using a WPF app or other GUI for the consumer, start that up now as well.
 
 #### 4. In a new terminal start the **Sample Producer** app.
 
-    Option 1. Open a new PowerShell window and run the following commands
+Option 1. Open a new PowerShell window and run the following commands
 
-    ```
-    cd samples/EventStreamProcessing.Sample.Producer
-    dotnet run
-    ```
+```
+cd samples/EventStreamProcessing.Sample.Producer
+dotnet run
+```
 
-    Option 2. Using Visual Studio 2019
+Option 2. Using Visual Studio 2019
 
-    1. Right-click on the `EventStreamProcessing.Sample.Producer` project in the Solution Explorer and select *Set as Startup Project*
-    2. Right-Click on the project again and select "Rebuild"
-    3. Press `CTRL + F5` (aka 'start without debugging') 
+  1. Right-click on the `EventStreamProcessing.Sample.Producer` project in the Solution Explorer and select *Set as Startup Project*
+  2. Right-Click on the project again and select "Rebuild"
+  3. Press `CTRL + F5` (aka 'start without debugging') 
 
 At this point, you should be able to see something similar to the following screenshot; with the Producer, Worker and Confluent running.
 


### PR DESCRIPTION
This was my experience while adding a Windows GUI application to the example. Following the Mac only steps led to some dead ends.

If necessary, I can open another PR with the actual WPF GUI project I built, but I was afraid that would limit the audience to Windows only.  Let me know if you're still like to see this and I can add it in.